### PR TITLE
Documentation upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,17 @@ Docker containers for [actualbudget](https://actualbudger.org) backup to remote.
 
 Heavily inspired at [vaultwarden-backup](https://github.com/ttionya/vaultwarden-backup)
 
-## Usage
-
 > **Important:** We assume you already read the `actualbudget` [documentation](https://actualbudget.org/docs/), and have an instance up and running.
 
-### Getting started guide
+## Getting started guide
 
-The fastest way to get started is with the [getting started guide](docs/getting-started.md), which contains the required config to get running as quickly as possible. This readme contains the full details of all the extras you might need to run as well.
+The fastest way to get started is with the [getting started guide](docs/getting-started.md), which contains the required config to get running as quickly as possible. This README contains the full details of all the extras you might need to run as well.
+
+## Usage
 
 ### Configure Rclone (⚠️ MUST READ ⚠️)
 
 > **For backup, you need to configure Rclone first, otherwise the backup tool will not work.**
->
-> **For restore, it is not necessary.**
 
 We upload the backup files to the storage system by [Rclone](https://rclone.org/).
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Password for the actual budget server. Single quotes must be escaped with a back
 
 Actual Sync ID. You can find this by logging into your Actual server in a web browser, go to `settings > show advanced settings` and the sync ID should be in the top block there.
 
-#### RCLONE_REMOTE_NAME
+### RCLONE_REMOTE_NAME
 
 The name of the Rclone remote, which needs to be consistent with the remote name in the rclone config.
 
@@ -117,13 +117,13 @@ docker run --rm -it \
 
 Default: `ActualBudgetBackup`
 
-#### RCLONE_REMOTE_DIR
+### RCLONE_REMOTE_DIR
 
 The folder where backup files are stored in the storage system.
 
 Default: `/ActualBudgetBackup/`
 
-#### RCLONE_GLOBAL_FLAG
+### RCLONE_GLOBAL_FLAG
 
 Rclone global flags, see [flags](https://rclone.org/flags/).
 
@@ -131,19 +131,19 @@ Rclone global flags, see [flags](https://rclone.org/flags/).
 
 Default: `''`
 
-#### CRON
+### CRON
 
 Schedule to run the backup script, based on [`supercronic`](https://github.com/aptible/supercronic). You can test the rules [here](https://crontab.guru/#0_0_*_*_*).
 
 Default: `0 0 * * *` (run the script at 12AM every day)
 
-#### BACKUP_KEEP_DAYS
+### BACKUP_KEEP_DAYS
 
 Only keep last a few days backup files in the storage system. Set to `0` to keep all backup files.
 
 Default: `0`
 
-#### BACKUP_FILE_SUFFIX
+### BACKUP_FILE_SUFFIX
 
 Each backup file is suffixed by default with `%Y%m%d`. If you back up your budget multiple times a day, that suffix is not unique any more. This environment variable allows you to append a unique suffix to that date to create a unique backup name.
 
@@ -155,7 +155,7 @@ Please use the [date man page](https://man7.org/linux/man-pages/man1/date.1.html
 
 Default: `%Y%m%d`
 
-#### TIMEZONE
+### TIMEZONE
 
 Set your timezone name.
 
@@ -168,7 +168,7 @@ Default: `UTC`
 
 > **You don't need to change these environment variables unless you know what you are doing.**
 
-#### BACKUP_FILE_DATE
+### BACKUP_FILE_DATE
 
 You should use the [`BACKUP_FILE_SUFFIX`](#backup_file_suffix) environment variable instead.
 
@@ -178,7 +178,7 @@ Same rule as [`BACKUP_FILE_DATE_SUFFIX`](#backup_file_date_suffix).
 
 Default: `%Y%m%d`
 
-#### BACKUP_FILE_DATE_SUFFIX
+### BACKUP_FILE_DATE_SUFFIX
 
 You should use the [`BACKUP_FILE_SUFFIX`](#backup_file_suffix) environment variable instead.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker run --rm -it \
 
 #### Use Docker Compose (Recommend)
 
-Download `docker-compose.yml` to you machine, edit environment variables and start it.
+Download `docker-compose.yml` to you machine, edit the [environment variables](#environment-variables) and start it.
 
 You need to go to the directory where the `docker-compose.yml` file is saved.
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,21 @@ Heavily inspired at [vaultwarden-backup](https://github.com/ttionya/vaultwarden-
 
 ## Usage
 
-> **Important:** We assume you already read the `actualbudget` [documentation](https://actualbudget.org/docs/). And have an insteance up and running.
+> **Important:** We assume you already read the `actualbudget` [documentation](https://actualbudget.org/docs/), and have an instance up and running.
+
+### Getting started guide
+
+The fastest way to get started is with the [getting started guide](docs/getting-started.md), which contains the required config to get running as quickly as possible. This readme contains the full details of all the extras you might need to run as well.
 
 ### Configure Rclone (⚠️ MUST READ ⚠️)
 
 > **For backup, you need to configure Rclone first, otherwise the backup tool will not work.**
-> 
+>
 > **For restore, it is not necessary.**
 
 We upload the backup files to the storage system by [Rclone](https://rclone.org/).
 
-Visit [GitHub](https://github.com/rclone/rclone) for more storage system tutorials. Different systems get tokens differently.
+Visit [Rclone's documentation](https://rclone.org/docs/) for more storage system tutorials. Different systems get tokens differently.
 
 #### Configure and Check
 
@@ -47,10 +51,6 @@ docker run --rm -it \
 # drive_type = personal
 ```
 
-<br>
-
-
-
 ### Backup
 
 #### Use Docker Compose (Recommend)
@@ -73,7 +73,7 @@ docker-compose restart
 docker-compose down
 ```
 
-#### Automatic Backups
+#### Automatic Backups without docker compose
 
 Start the backup container with default settings. (automatic backup at 12AM every day)
 
@@ -85,23 +85,21 @@ docker run -d \
   rodriguestiago0/actualbudget-backup:latest
 ```
 
-<br>
-
 ## Environment Variables
 
-> **Note:** All environment variables have default values, you can use the docker image without setting any environment variables.
+> **Note:** The container will run with no environment variables specified without error, however if you haven't set at least `ACTUAL_BUDGET_URL`, `ACTUAL_BUDGET_PASSWORD`, and `ACTUAL_BUDGET_SYNC_ID`, no backup will successfully happen.
 
 ### ACTUAL_BUDGET_URL
 
-URL for the actual budget server
+URL for the actual budget server, without a trailing `/`
 
 ### ACTUAL_BUDGET_PASSWORD
 
-Password for the actual budget serer
+Password for the actual budget server. Single quotes and backslashes must be escaped with a backslash. Double quotes, spaces, and the dollar symbol will break the script at present, so change your password if it has those symbols in it.
 
 ### ACTUAL_BUDGET_SYNC_ID
 
-Actual Sync ID. Check settings.
+Actual Sync ID. You can find this by logging into your Actual server in a web browser, go to `settings > show advanced settings` and the sync ID should be in the top block there.
 
 #### RCLONE_REMOTE_NAME
 
@@ -141,7 +139,6 @@ Schedule to run the backup script, based on [`supercronic`](https://github.com/a
 
 Default: `0 0 * * *` (run the script at 12AM every day)
 
-
 #### BACKUP_KEEP_DAYS
 
 Only keep last a few days backup files in the storage system. Set to `0` to keep all backup files.
@@ -150,7 +147,7 @@ Default: `0`
 
 #### BACKUP_FILE_SUFFIX
 
-Each backup file is suffixed by default with `%Y%m%d`. If you back up your budget multiple times a day, that suffix is not unique anymore. This environment variable allows you to append a unique suffix to that date to create a unique backup name.
+Each backup file is suffixed by default with `%Y%m%d`. If you back up your budget multiple times a day, that suffix is not unique any more. This environment variable allows you to append a unique suffix to that date to create a unique backup name.
 
 You can use any character except for `/` since it cannot be used in Linux file names.
 
@@ -167,7 +164,6 @@ Set your timezone name.
 Here is timezone list at [wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 Default: `UTC`
-
 
 <details>
 <summary><strong>※ Other environment variables</strong></summary>
@@ -199,8 +195,6 @@ Default: `''`
 
 </details>
 
-<br>
-
 ## Using `.env` file
 
 If you prefer using an env file instead of environment variables, you can map the env file containing the environment variables to the `/.env` file in the container.
@@ -210,9 +204,6 @@ docker run -d \
   --mount type=bind,source=/path/to/env,target=/.env \
   rodriguestiago0/actualbudget-backup:latest
 ```
-
-<br>
-
 
 ## Docker Secrets
 
@@ -224,15 +215,9 @@ docker run -d \
   rodriguestiag0/actualbudget-backup:latest
 ```
 
-<br>
-
 ## About Priority
 
 We will use the environment variables first, followed by the contents of the file ending in `_FILE` as defined by the environment variables. Next, we will use the contents of the file ending in `_FILE` as defined in the `.env` file, and finally the values from the `.env` file itself.
-
-<br>
-
-
 
 ## Advance
 
@@ -240,7 +225,6 @@ We will use the environment variables first, followed by the contents of the fil
 - [Multiple sync ids](docs/multiple-sync-ids.md)
 - [Manually trigger a backup](docs/manually-trigger-a-backup.md)
 
-<br>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Actual Budgett backup
+# Actual Budget backup
 
 Docker containers for [actualbudget](https://actualbudger.org) backup to remote.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ URL for the actual budget server, without a trailing `/`
 
 ### ACTUAL_BUDGET_PASSWORD
 
-Password for the actual budget server. Single quotes and backslashes must be escaped with a backslash. Double quotes, spaces, and the dollar symbol will break the script at present, so change your password if it has those symbols in it.
+Password for the actual budget server. Single quotes must be escaped with a backslash. Double quotes, spaces, backslashes and the dollar symbol will break the script at present, so change your password if it has those symbols in it.
 
 ### ACTUAL_BUDGET_SYNC_ID
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,12 @@ services:
     image: rodriguestiago0/actualbudget-backup:latest
     restart: always
     environment:
-      - PGID
     #   RCLONE_REMOTE_NAME: 'ActualBudgetBackup'
     #   RCLONE_REMOTE_DIR: '/ActualBudgetBackup/'
     #   RCLONE_GLOBAL_FLAG: ''
-    #   ACTUAL_BUDGET_URL: 'https://localhost:5006'
-    #   ACTUAL_BUDGET_PASSWORD: ''
-    #   ACTUAL_BUDGET_SYNC_ID: ''
+        ACTUAL_BUDGET_URL: 'https://actual.example.com'
+        ACTUAL_BUDGET_PASSWORD: ''
+        ACTUAL_BUDGET_SYNC_ID: ''
     #   CRON: '0 0 * * *'
     #   BACKUP_FILE_SUFFIX: '%Y%m%d'
     #   BACKUP_KEEP_DAYS: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   backup:
     image: rodriguestiago0/actualbudget-backup:latest

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,57 @@
+# Getting Started
+
+This doc should contain the minimal steps required to get a working backup going. It assumes you already have a box with docker running that this will run on, and that that box is able to talk to your Actual server over https.
+
+## Setup
+
+There are two parts to the setup, one to tell the backup system how to connect to your Actual server, and the other to tell the backup system how to connect to the storage system you are going to save the backup to. We will setup the storage first, and then the connection to Actual.
+
+### Storage
+
+The backup system uses Rclone to talk to the storage system. At time of writing, Rclone supports 55 different storage systems, so this guide will not tell you exactly how to setup your storage system, for that you should check out [Rclone's excellent documentation](https://rclone.org/docs/). However these are the required steps to get it working in this system.
+
+1. Run the following code to start the setup. Note: if you're running this on Windows, replace the `\` at the end of each line with `\`` (backticks)
+
+   ```shell
+   docker run --rm -it \
+     --mount type=volume,source=actualbudget-rclone-data,target=/config/ \
+     rodriguestiago0/actualbudget-backup:latest \
+     rclone config
+   ```
+
+2. Choose the option to create a new remote, and when prompted for a name call it "ActualBudgetBackup".
+3. From here, follow the instructions from Rclone's Documentation to set up your storage.
+
+The only thing to note that we're doing differently is that Rclone is running inside Docker. There are a few storage providers that require you to launch a web browser as part of the auth flow (e.g Google Drive and OneDrive). If you are using one of these methods, you will need to answer "no" to Rclone launching the browser for you (as the Docker container is headless), and follow the instructions it will then provide to use Rclone on a different machine to get the auth token.
+
+### Connection to Actual
+
+Next we need to tell the container how it's going to talk to your Actual server. To start with, download the [`docker-compose.yml`](/docker-compose.yml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. I will go over the mandatory and most used fields here, for the others, check the [README](/README) for what they do.
+
+#### Mandatory fields
+
+`ACTUAL_BUDGET_URL` - First, we need to tell it the url of the website, including the protocol, and the port (if applicable) (NB: Do NOT add a trailing / to this. For e.g. `ACTUAL_BUDGET_URL: 'https://acutal.example.com'` will work, but `ACTUAL_BUDGET_URL: 'https://acutal.example.com/'` will not)
+
+`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains either a `'` or a `\`, you need to escape them e.g. if your password was `123Super'Pass\word` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super\'Pass\\word'`. If your password contains `"`, change it so it doesn't. It's possible to make that work, but it's painful.
+
+`ACTUAL_BUDGET_SYNC_ID` - Finally, this identifies the budget on the server. To get this ID, open Actual in your web browser, and go to `Settings`. At the bottom, click `Show advanced settings`, and the `Sync ID` should be in the top section there.
+
+#### Optional fields you might need to change
+
+`ACTUAL_BUDGET_SYNC_ID_1` If you have multiple budgets to backup, you can add more sync IDs by using the `ACTUAL_BUDGET_SYNC_ID_1: ''` field to hold the second ID, and you can add as many of those as you want by incrementing the number `ACTUAL_BUDGET_SYNC_ID_2`, `ACTUAL_BUDGET_SYNC_ID_3`... etc.
+
+`CRON` - This line tells the container what time to perform the backup. By default, it happens at midnight every day. This is fine if your computer is on 24/7, but if the machine you're running this on is only active in the day, you might want to change it to happen when you know it will be on. To do this, enter any valid cron string, but note that the default config only allows one backup per day, so making it occur more frequently will overwrite the first backup.
+
+`TIMEZONE` - your local timezone. If you're changing the cron time, you will also want to set the timezone, else it will not run at the time you want it to. It's entered in standard TZ data format. e.g. to set the timezone to UK time, you'd set it to `TIMEZONE: 'Europe/London'`
+
+`BACKUP_KEEP_DAYS` - by default, this tool never deletes old backups. To change this behaviour, set this to the number of days to keep backups for. e.g. for a weeks worth of backups, set `BACKUP_KEEP_DAYS: 7`
+
+## Testing
+
+Now all the config is set, you should run a test backup to confirm all the config is correct. To do that, run the following command from the folder where you have the docker compose file:
+
+```shell
+docker compose run --rm backup backup
+```
+
+If everything is ok, this will run for a few seconds, and will finish on a line similar to `upload backup file to storage system [backup/backup.<ID>.20250208.zip -> ActualBudgetBackup:/ActualBudgetBackup]`. If you check your storage system, you should now have a file called `backup.<ID>.20250208.zip` stored within there. If anything went wrong, go back and check all your env variables. If you can't work out what's gone wrong, file an issue in this repo.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ The only thing to note that we're doing differently is that Rclone is running in
 
 ### Connection to Actual
 
-Next we need to tell the container how it's going to talk to your Actual server. To start with, download the [`docker-compose.yml`](/docker-compose.yml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. I will go over the mandatory and most used fields here, for the others, check the [README](/README) for what they do.
+Next we need to tell the container how it's going to talk to your Actual server. To start with, download the [`docker-compose.yml`](/docker-compose.yml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. I will go over the mandatory and most used fields here, for the others, check the [README](/README.md) for what they do.
 
 #### Mandatory fields
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,25 +26,25 @@ The only thing to note that we're doing differently is that Rclone is running in
 
 ### Connection to Actual
 
-Next you need to tell the container how it's going to talk to your Actual server. To start with, download the [`docker-compose.yml`](/docker-compose.yml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. This guide will go over the mandatory and most used fields here, for the others, check the [README](/README.md) for what they do.
+Next you need to tell the container how it's going to talk to your Actual server. To start with, download the [`docker-compose.yml`](/docker-compose.yml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. This guide will go over the mandatory and most used fields here. For the the full list, check the [README](/README.md) for what they do.
 
 #### Mandatory fields
 
 `ACTUAL_BUDGET_URL` - First, set the url of the Actual Server, including the protocol, (and the port if applicable) (NB: Do NOT add a trailing / to this. e.g. `ACTUAL_BUDGET_URL: 'https://acutal.example.com'` will work, but `ACTUAL_BUDGET_URL: 'https://acutal.example.com/'` will not)
 
-`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains any singly quotes (`'`), you need to escape them e.g. if your password was `123Super'Password` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super\'Password'`. If your password contains any of `"`, `$`, `\` or a space, change it so it doesn't. It's possible to make that work, but it's painful.)
+`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains any singly quotes (`'`), you need to escape them e.g. if your password was `123Super'Password` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super\'Password'`. If your password contains any of `"`, `$`, or `\`; change it so it doesn't. It's possible to make that work, but it's painful.)
 
 `ACTUAL_BUDGET_SYNC_ID` - Finally, this identifies the budget on the server. To get this ID, open Actual in your web browser, and go to `Settings`. At the bottom, click `Show advanced settings`, and the `Sync ID` should be in the top section there.
 
 #### Optional fields you might need to change
 
-`ACTUAL_BUDGET_SYNC_ID_1` If you have multiple budgets to backup, you can add more sync IDs by using the `ACTUAL_BUDGET_SYNC_ID_1: ''` field to hold the second ID, and you can add as many of those as you want by incrementing the number `ACTUAL_BUDGET_SYNC_ID_2`, `ACTUAL_BUDGET_SYNC_ID_3`... etc.
-
-`CRON` - This line tells the container what time to perform the backup. By default, it happens at midnight every day. This is fine if your computer is on 24/7, but if the machine you're running this on is only active in the day, you might want to change it to happen when you know it will be on. To do this, enter any valid cron string, but note that the default config only allows one backup per day, so making it occur more frequently will overwrite the first backup.
+`CRON` - This line tells the container what time to perform the backup. By default, it happens at midnight UTC every day. This is fine if your computer is on 24/7, but if the machine you're running this on is only active in the day, you might want to change it to happen when you know it will be on. To do this, enter any valid cron string, but note that the default config only allows one backup per day, so making it occur more frequently will overwrite the first backup.
 
 `TIMEZONE` - your local timezone. If you're changing the cron time, you will also want to set the timezone, else it will not run at the time you want it to. It's entered in standard TZ data format. e.g. to set the timezone to UK time, you'd set it to `TIMEZONE: 'Europe/London'`
 
 `BACKUP_KEEP_DAYS` - by default, this tool never deletes old backups. To change this behaviour, set this to the number of days to keep backups for. e.g. for a weeks worth of backups, set `BACKUP_KEEP_DAYS: 7`
+
+`ACTUAL_BUDGET_SYNC_ID_1` If you have multiple budgets to backup, you can add more sync IDs by using the `ACTUAL_BUDGET_SYNC_ID_1: ''` field to hold the second ID, and you can add as many of those as you want by incrementing the number `ACTUAL_BUDGET_SYNC_ID_2`, `ACTUAL_BUDGET_SYNC_ID_3`… etc.
 
 ## Testing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This doc should contain the minimal steps required to get a working backup going
 
 ## Setup
 
-There are two parts to the setup, one to tell the backup system how to connect to your Actual server, and the other to tell the backup system how to connect to the storage system you are going to save the backup to. We will setup the storage first, and then the connection to Actual.
+There are two parts to the setup, one to tell the backup system how to connect to your Actual server, and the other to tell the backup system how to connect to the storage system you are going to save the backup to. This guide will cover setting up the storage first, and then the connection to Actual.
 
 ### Storage
 
@@ -26,13 +26,13 @@ The only thing to note that we're doing differently is that Rclone is running in
 
 ### Connection to Actual
 
-Next we need to tell the container how it's going to talk to your Actual server. To start with, download the [`docker-compose.yml`](/docker-compose.yml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. I will go over the mandatory and most used fields here, for the others, check the [README](/README.md) for what they do.
+Next you need to tell the container how it's going to talk to your Actual server. To start with, download the [`docker-compose.yml`](/docker-compose.yml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. This guide will go over the mandatory and most used fields here, for the others, check the [README](/README.md) for what they do.
 
 #### Mandatory fields
 
-`ACTUAL_BUDGET_URL` - First, we need to tell it the url of the website, including the protocol, and the port (if applicable) (NB: Do NOT add a trailing / to this. For e.g. `ACTUAL_BUDGET_URL: 'https://acutal.example.com'` will work, but `ACTUAL_BUDGET_URL: 'https://acutal.example.com/'` will not)
+`ACTUAL_BUDGET_URL` - First, set the url of the Actual Server, including the protocol, (and the port if applicable) (NB: Do NOT add a trailing / to this. e.g. `ACTUAL_BUDGET_URL: 'https://acutal.example.com'` will work, but `ACTUAL_BUDGET_URL: 'https://acutal.example.com/'` will not)
 
-`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains either a `'` or a `\`, you need to escape them e.g. if your password was `123Super'Pass\word` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super\'Pass\\word'`. If your password contains any of `"`, `$`, or a space, change it so it doesn't. It's possible to make that work, but it's painful.
+`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains any singly quotes (`'`), you need to escape them e.g. if your password was `123Super'Password` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super\'Password'`. If your password contains any of `"`, `$`, `\` or a space, change it so it doesn't. It's possible to make that work, but it's painful.)
 
 `ACTUAL_BUDGET_SYNC_ID` - Finally, this identifies the budget on the server. To get this ID, open Actual in your web browser, and go to `Settings`. At the bottom, click `Show advanced settings`, and the `Sync ID` should be in the top section there.
 
@@ -55,3 +55,13 @@ docker compose run --rm backup backup
 ```
 
 If everything is ok, this will run for a few seconds, and will finish on a line similar to `upload backup file to storage system [backup/backup.<ID>.20250208.zip -> ActualBudgetBackup:/ActualBudgetBackup]`. If you check your storage system, you should now have a file called `backup.<ID>.20250208.zip` stored within there. If anything went wrong, go back and check all your env variables. If you can't work out what's gone wrong, file an issue in this repo.
+
+## Starting the automatic backup
+
+If your test succeeded, you can now start docker running permanently. To do this, issue the following command:
+
+```shell
+docker compose up -d
+```
+
+This will start the container running, and it will automatically start every time docker does. The backup will be performed at whatever time you specified for `CRON`, or at midnight UTC if you didn't specify.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ There are two parts to the setup, one to tell the backup system how to connect t
 
 The backup system uses Rclone to talk to the storage system. At time of writing, Rclone supports 55 different storage systems, so this guide will not tell you exactly how to setup your storage system, for that you should check out [Rclone's excellent documentation](https://rclone.org/docs/). However these are the required steps to get it working in this system.
 
-1. Run the following code to start the setup. Note: if you're running this on Windows, replace the `\` at the end of each line with `\`` (backticks)
+1. Run the following code to start the setup. Note: if you're running this on Windows, replace the `\` at the end of each line with `` ` `` (backticks)
 
    ```shell
    docker run --rm -it \
@@ -32,7 +32,7 @@ Next we need to tell the container how it's going to talk to your Actual server.
 
 `ACTUAL_BUDGET_URL` - First, we need to tell it the url of the website, including the protocol, and the port (if applicable) (NB: Do NOT add a trailing / to this. For e.g. `ACTUAL_BUDGET_URL: 'https://acutal.example.com'` will work, but `ACTUAL_BUDGET_URL: 'https://acutal.example.com/'` will not)
 
-`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains either a `'` or a `\`, you need to escape them e.g. if your password was `123Super'Pass\word` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super\'Pass\\word'`. If your password contains `"`, change it so it doesn't. It's possible to make that work, but it's painful.
+`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains either a `'` or a `\`, you need to escape them e.g. if your password was `123Super'Pass\word` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super\'Pass\\word'`. If your password contains any of `"`, `$`, or a space, change it so it doesn't. It's possible to make that work, but it's painful.
 
 `ACTUAL_BUDGET_SYNC_ID` - Finally, this identifies the budget on the server. To get this ID, open Actual in your web browser, and go to `Settings`. At the bottom, click `Show advanced settings`, and the `Sync ID` should be in the top section there.
 

--- a/docs/manually-trigger-a-backup.md
+++ b/docs/manually-trigger-a-backup.md
@@ -4,13 +4,17 @@ Sometimes, it's necessary to manually trigger backup actions.
 
 This can be useful when other programs are used to consistently schedule tasks or to verify that environment variables are properly configured.
 
-<br>
-
-
-
 ## Usage
 
 Previously, performing an immediate backup required overwriting the entrypoint of the image. However, with the new setup, you can perform a backup directly with a parameterless command.
+
+If you have already configured your docker compose file correctly, you can trigger this with the following command (You will need to `docker compose down` the running container first if it is running):
+
+```shell
+docker compose run --rm backup backup
+```
+
+If you have not configured Docker compose yet, you can run the image manually, and specify the env variables on the cli as follows
 
 ```shell
 docker run \
@@ -24,5 +28,3 @@ docker run \
 You also need to mount the rclone config file and set the environment variables.
 
 The only difference is that the environment variable `CRON` does not work because it does not start the CRON program, but exits the container after the backup is done.
-
-<br>


### PR DESCRIPTION
As discussed on Discord, I cut down my blog post to a "Getting Started" guide. I've also tweaked the README to make the getting started guide the primary call-to-action, and to fix a few things to make it parse a bit better in my opinion (and to make my Markdown linter stop screaming at me lol). 

I've also adjusted the Docker Compose file to remove the Version line, that causes warnings now that it has been deprecated, and to explictly call out the env variables needed for a successful backup. If this change isn't wanted, I can remove it from the PR.

Happy to discuss any of this either here or on Discord if you have comments/requests for changes.