### PR TITLE
Improve password handling (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ URL for the actual budget server, without a trailing `/`
 
 ### ACTUAL_BUDGET_PASSWORD
 
-Password for the actual budget server. Single quotes must be escaped with a backslash. Double quotes, spaces, backslashes and the dollar symbol will break the script at present, so change your password if it has those symbols in it.
+Password for the actual budget server. If you're setting this through the docker-compose file, Single quotes must be escaped with by doubling them up. e.g. if your password is `SuperGo'oodPassw\ord"1` you would enter `ACTUAL_BUDGET_PASSWORD: 'SuperGo''oodPassw\ord"1'`. If you're using the env file method, you will need to work out your own way to encode your password without breaking the env file.
 
 ### ACTUAL_BUDGET_SYNC_ID
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ Next you need to tell the container how it's going to talk to your Actual server
 
 `ACTUAL_BUDGET_URL` - First, set the url of the Actual Server, including the protocol, (and the port if applicable) (NB: Do NOT add a trailing / to this. e.g. `ACTUAL_BUDGET_URL: 'https://acutal.example.com'` will work, but `ACTUAL_BUDGET_URL: 'https://acutal.example.com/'` will not)
 
-`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains any singly quotes (`'`), you need to escape them e.g. if your password was `123Super'Password` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super\'Password'`. If your password contains any of `"`, `$`, or `\`; change it so it doesn't. It's possible to make that work, but it's painful.)
+`ACTUAL_BUDGET_PASSWORD` - Second, you need to put the password for your budget. (NB: If your password contains any single quotes (`'`), you need to escape the by doubling them up e.g. if your password was `123Super'Password` you would need to enter `ACTUAL_BUDGET_PASSWORD: '123Super''Password'`.
 
 `ACTUAL_BUDGET_SYNC_ID` - Finally, this identifies the budget on the server. To get this ID, open Actual in your web browser, and go to `Settings`. At the bottom, click `Show advanced settings`, and the `Sync ID` should be in the top section there.
 

--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -199,8 +199,8 @@ function init_actual_env(){
 
     get_env ACTUAL_BUDGET_SYNC_ID
 
-    if [[ -z "${!ACTUAL_BUDGET_SYNC_ID}" ]]; then        
-        colot red "Invalid sync id"
+    if [[ -z "${ACTUAL_BUDGET_SYNC_ID}" ]]; then        
+        color red "Invalid sync id"
         exit 1
     fi 
     


### PR DESCRIPTION
While testing for writing my documentation at the weekend, I got incredibly jumbled up in how passwords and their escaping were being handled, and how it kept breaking on my test cases. This meant I wasn't happy the documentation I wrote around that was correct. I came at it again fresh at lunch time today, and went through the code to work out what was happening, and found I'd massively over complicated matters, by going around things the wrong way, and mixing myself up.

I started this PR as a plain documentation update, to simplify where I'd gone wrong, but in doing so I spotted a way to reduce the amount of escaping needed to the bare minimum. I've added a new function to backup.sh called `prepare_login_json`, that constructs the json we're sending to the server, and writing it to a file. `curl` has the ability to read the data it is `POST`-ing from a file, which skips the need to manually create the json on the command line, with all the quote escaping that requires.

The function to create the json file should also be safe and not need any escaping, because first it uses `printf` to create the two keyvalue pairs we care about (loginMethod: password, and password: $ACTUAL_BUDGET_PASSWORD) concatenated with the `NUL` character. This is then piped to `jq`, which splits the strings on `NUL`s, and then encodes each pair itself into valid json, that gets redirected to a temp file. Because `NUL` can never exist in a password, this always ends up with the full password being written, no matter what symbols are in it.

This is a little overkill, as writing it to a file without it needing to pass it on the command line would probably be easy enough to escape manually, but letting `jq` handle correctly encoding the password is much safer IMO, because as a dedicated json tool, it's got way more cover for edge cases than we could ever write.

The only other change was to fix a typo in `include.sh`, and remove an errant exclamation mark from the zero-length string test. That was breaking my build while testing, and doesn't appear to be present in the image on Dockerhub, so I'm not sure if something just didn't get built and pushed, but the code here works now, with all the test cases I could throw at it this evening.