### PR TITLE
Add support for backing up E2E encrypted backups

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,4 @@
 # ACTUAL_BUDGET_URL= #without quotes and the last /
 # ACTUAL_BUDGET_PASSWORD= #without quotes
 # ACTUAL_BUDGET_SYNC_ID= #without quotes
+# ACTUAL_BUDGET_E2E_PASSWORD=#without quotes

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ ARG USER_ID="1100"
 ENV LOCALTIME_FILE="/tmp/localtime"
 
 COPY scripts/*.sh /app/
+COPY scripts/*.py /app/
 
 RUN chmod +x /app/* \
-  && apk add --no-cache grep file bash supercronic curl jq \
+  && apk add --no-cache grep file bash supercronic curl jq python3 py3-pip \
+  && pip3 install --no-cache-dir --break-system-packages pycryptodome \
   && ln -sf "${LOCALTIME_FILE}" /etc/localtime \
   && addgroup -g "${USER_ID}" "${USER_NAME}" \
   && adduser -u "${USER_ID}" -Ds /bin/sh -G "${USER_NAME}" "${USER_NAME}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         ACTUAL_BUDGET_URL: 'https://actual.example.com'
         ACTUAL_BUDGET_PASSWORD: ''
         ACTUAL_BUDGET_SYNC_ID: ''
+    #   ACTUAL_BUDGET_E2E_PASSWORD: ''
     #   CRON: '0 0 * * *'
     #   BACKUP_FILE_SUFFIX: '%Y%m%d'
     #   BACKUP_KEEP_DAYS: 0

--- a/docs/e2e-encrypted-backups.md
+++ b/docs/e2e-encrypted-backups.md
@@ -1,0 +1,44 @@
+# End-to-end Encrypted Backups
+
+End-to-end encrypted backups are now supported. If you have specified a key in ActualBackup's End-to-end Encryption settings, they will be backed up successfully.
+**NOTE:** Similarly to ActualBackup's Export feature, if you back up an end-to-end encrypted file, it is backed up **without encryption**. This is because Actual Backup does not support importing encrypted backups - the database files must be in an unencrypted zip file for sucessful import.
+
+If it is necessary that these files remain encrypted, consider a per-file encryption solution, such as an rclone crypt remote.
+
+After you import your backup, you will have to set a new key to enable end-to-end encryption again.
+
+
+<br>
+
+## Usage
+If you are backing up a single E2E backup, use the environment variable `ACTUAL_BUDGET_E2E_PASSWORD` to set the same password used in ActualBackup.
+
+To set additional passwords for different sync targets, use the environment variables `ACTUAL_BUDGET_E2E_PASSWORD_N` where:
+
+- `N` is a serial number, starting from 1 and increasing consecutively for each additional password.
+
+Note that if the serial number is not consecutive or the value is empty, the script will break parsing the environment variables for E2E_PASSWORD ids.
+
+This means that if you are backing up a mixture of budgets where some are encrypted and some are not, you must still specify a `ACTUAL_BUDGET_E2E_PASSWORD_N` value for budgets that do not use an E2E password. You can use any value (such as 'null') but there must be something there or parsing will break.
+
+<br>
+
+#### Example
+
+```yml
+...
+environment:
+  # they have default values
+  ACTUAL_BUDGET_SYNC_ID: 'encrypted-random-guid'
+  ACTUAL_BUDGET_SYNC_ID_1: 'encrypted-random-guid-1'
+  ACTUAL_BUDGET_SYNC_ID_2: 'random-guid-2' (NOT ENCRYPTED)
+  ACTUAL_BUDGET_SYNC_ID_3: 'encrypted-random-guid-3'
+  ACTUAL_BUDGET_E2E_PASSWORD_: 'password'
+  ACTUAL_BUDGET_E2E_PASSWORD_1: 'password-1'
+  ACTUAL_BUDGET_E2E_PASSWORD_2: 'anything except empty'
+  ACTUAL_BUDGET_E2E_PASSWORD_3: 'password-3'
+  
+...
+```
+
+With the above example, even though `ACTUAL_BUDGET_SYNC_ID_2` identifies a budget which is not encrypted, `ACTUAL_BUDGET_E2E_PASSWORD_2` must still be a non-empty value.

--- a/docs/e2e-encrypted-backups.md
+++ b/docs/e2e-encrypted-backups.md
@@ -1,7 +1,9 @@
 # End-to-end Encrypted Backups
 
 End-to-end encrypted backups are now supported. If you have specified a key in ActualBackup's End-to-end Encryption settings, they will be backed up successfully.
-**NOTE:** Similarly to ActualBackup's Export feature, if you back up an end-to-end encrypted file, it is backed up **without encryption**. This is because Actual Backup does not support importing encrypted backups - the database files must be in an unencrypted zip file for sucessful import.
+<br>
+
+**NOTE:** Similarly to ActualBackup's Export feature, if you back up an end-to-end encrypted file, it is backed up **without encryption**. This is because Actual Backup does not support importing encrypted backups - the database files must be in an unencrypted zip file for successful import.
 
 If it is necessary that these files remain encrypted, consider a per-file encryption solution, such as an rclone crypt remote.
 

--- a/scripts/aes-256-gcm-decrypt.py
+++ b/scripts/aes-256-gcm-decrypt.py
@@ -9,8 +9,6 @@ from Crypto.Cipher import AES
 RED = '\033[31m'
 RESET = '\033[0m'
 
-#TODO: For environ.get calls check if they are empty before subscripting them
-#TODO: You really should just pass these as command line args from bash as it does not require an export
 
 #Setup argparse
 parser = argparse.ArgumentParser(description='Process encryption params')

--- a/scripts/aes-256-gcm-decrypt.py
+++ b/scripts/aes-256-gcm-decrypt.py
@@ -1,0 +1,55 @@
+import base64
+import hashlib
+from os import environ
+from sys import exit
+from Crypto.Cipher import AES
+
+#Color Presets
+RED = '\033[31m'
+RESET = '\033[0m'
+
+#TODO: For environ.get calls check if they are empty before subscripting them
+#TODO: You really should just pass these as command line args from bash as it does not require an export
+#Read from environment
+password = environ.get('E2E_PASS_ARG').encode('utf-8')
+#Note that ActualBudget uses the base64 encoded salt as-is with no decoding
+salt = environ.get('SALT').encode('utf-8')
+iv_b64 = environ.get('IV')
+auth_tag_b64 = environ.get('AUTH_TAG')
+
+#Check if any variables were not set properly
+check_not_empty = {
+    'E2E_PASS_ARG':password,
+    'SALT':salt,
+    'IV':iv_b64,
+    'AUTH_TAG':auth_tag_b64,
+}
+if not all(check_not_empty.values()):
+    empty = [name for name, value in check_not_empty.items() if not value]
+    print(f"{RED}The following required variables are empty:{RESET}", ', '.join(missing))
+    sys.exit(1)
+#Set input and output paths
+encrypted_file_path = environ.get('BACKUP_FILE_ZIP_ARG')
+decrypted_file_path = environ.get('BACKUP_FILE_ZIP_ARG')[:-4]+"-decrypted.zip"
+
+# Decode base64 inputs as needed
+iv = base64.b64decode(iv_b64)
+auth_tag = base64.b64decode(auth_tag_b64)
+
+# Derive the 256-bit AES key using PBKDF2-HMAC-SHA512
+key = hashlib.pbkdf2_hmac('sha512', password, salt, 10000, dklen=32)
+
+# Read ciphertext from file
+with open(encrypted_file_path, 'rb') as f:
+    ciphertext = f.read()
+
+# Initialize AES-GCM cipher for decryption using key and iv
+cipher = AES.new(key, AES.MODE_GCM, nonce=iv)
+
+# Decrypt ciphertext and verify authentication tag
+plaintext = cipher.decrypt_and_verify(ciphertext, auth_tag)
+
+# Write decrypted output to <input>_decrypted.zip
+#TODO above
+with open(decrypted_file_path, 'wb') as f:
+    f.write(plaintext)

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -53,7 +53,7 @@ function decrypt() {
 	#$FILE_ID and $TOKEN are still set properly so they can be used here
     local JSON=$(jq -n --arg token "$TOKEN" --arg fileId "$FILE_ID" \
   '{token: $token, fileId: $fileId}')
-    local SALT=$(curl "${ACTUAL_BUDGET_URL}/sync/user-get-key" -X POST -H "Content-Type: application/json" --data-raw "$JSON" | jq --raw-output ".data.salt")
+    local SALT=$(curl -s "${ACTUAL_BUDGET_URL}/sync/user-get-key" -X POST -H "Content-Type: application/json" --data-raw "$JSON" | jq --raw-output ".data.salt")
     local IV=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/get-user-file-info" \--header "X-ACTUAL-TOKEN: $TOKEN" \--header "X-ACTUAL-FILE-ID: $FILE_ID" | jq --raw-output ".data.encryptMeta.iv")
     local AUTH_TAG=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/get-user-file-info" \--header "X-ACTUAL-TOKEN: $TOKEN" \--header "X-ACTUAL-FILE-ID: $FILE_ID" | jq --raw-output ".data.encryptMeta.authTag")
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -22,55 +22,70 @@ function download_actual_budget() {
     color blue "Downloading Actual Budget backup"
     color green "Login into Actual Budget" 
     prepare_login_json
-    TOKEN="$(curl -s --location "${ACTUAL_BUDGET_URL}/account/login" --header 'Content-Type: application/json' --data @/tmp/login.json  | jq --raw-output '.data.token')"
+    #We will use $TOKEN in decrypt step
+	TOKEN="$(curl -s --location "${ACTUAL_BUDGET_URL}/account/login" --header 'Content-Type: application/json' --data @/tmp/login.json  | jq --raw-output '.data.token')"
     rm /tmp/login.json
-    for ACTUAL_BUDGET_SYNC_ID_X in "${ACTUAL_BUDGET_SYNC_ID_LIST[@]}"
+    local i=0
+	for ACTUAL_BUDGET_SYNC_ID_X in "${ACTUAL_BUDGET_SYNC_ID_LIST[@]}"
     do
         color green "Get file id for ${ACTUAL_BUDGET_SYNC_ID_X}"
         backup_file_name $ACTUAL_BUDGET_SYNC_ID_X
 
-        #Explicit exports in this file are needed for visibility from python
-        export FILE_ID=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/list-user-files" \--header "X-ACTUAL-TOKEN: $TOKEN" | jq --raw-output ".data[] | select( [ .groupId | match(\"$ACTUAL_BUDGET_SYNC_ID_X\") ] | any) | .fileId")
+        #We will use $FILE_ID in decrypt step
+		FILE_ID=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/list-user-files" \--header "X-ACTUAL-TOKEN: $TOKEN" | jq --raw-output ".data[] | select( [ .groupId | match(\"$ACTUAL_BUDGET_SYNC_ID_X\") ] | any) | .fileId")
         color green "Downloading backup files"
         curl -s --location "${ACTUAL_BUDGET_URL}/sync/download-user-file" --header "X-ACTUAL-TOKEN: $TOKEN" --header "X-ACTUAL-FILE-ID: $FILE_ID" --output "${BACKUP_FILE_ZIP}"
         ENCRYPT_KEY_ID=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/list-user-files" \--header "X-ACTUAL-TOKEN: $TOKEN" | jq --raw-output ".data[] | select( [ .groupId | match(\"$ACTUAL_BUDGET_SYNC_ID_X\") ] | any) | .encryptKeyId")
 		color blue "[DEBUG] ENCRYPT_KEY_ID: ${ENCRYPT_KEY_ID}"
         if [ "$ENCRYPT_KEY_ID" != "null" ]; then
-            decrypt
+            BACKUP_FILE_BIN="${BACKUP_FILE_ZIP:0:-4}.bin"
+			cp "${BACKUP_FILE_ZIP}" "${BACKUP_FILE_BIN}"
+			decrypt "${i}"
+		else
+		    color blue "File ${BACKUP_FILE_ZIP} is NOT encrypted. Backing up normally..."
         fi
+        ((i++))
     done
    
 }
 
 function decrypt() {
-    color blue "File ${BACKUP_FILE_ZIP} is encrypted. Decrypting data..."
+	color blue "File ${BACKUP_FILE_ZIP} is encrypted. Decrypting data..."
     
-    #FILE_ID and ENCRYPT_KEY_ID are still set to the current file so they can be used here
-    #TOKEN is cross function
-    color yellow "[DEBUG]Attempting to get SALT"
+    
+	#$FILE_ID and $TOKEN are still set properly so they can be used here
     local JSON=$(jq -n --arg token "$TOKEN" --arg fileId "$FILE_ID" \
   '{token: $token, fileId: $fileId}')
-    export SALT=$(curl "${ACTUAL_BUDGET_URL}/sync/user-get-key" -X POST -H "Content-Type: application/json" --data-raw "$JSON" | jq --raw-output ".data.salt")
-    color yellow "[DEBUG] Attempting to get IV"
-    export IV=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/get-user-file-info" \--header "X-ACTUAL-TOKEN: $TOKEN" \--header "X-ACTUAL-FILE-ID: $FILE_ID" | jq --raw-output ".data.encryptMeta.iv")
-    color yellow "[DEBUG] Attempting to get Auth_Tag"
-    export AUTH_TAG=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/get-user-file-info" \--header "X-ACTUAL-TOKEN: $TOKEN" \--header "X-ACTUAL-FILE-ID: $FILE_ID" | jq --raw-output ".data.encryptMeta.authTag")
-	export E2E_PASS_ARG="${ACTUAL_BUDGET_E2E_PASSWORD}"
-	export BACKUP_FILE_ZIP_ARG="${BACKUP_FILE_ZIP}"
-    color blue "[DEBUG] Required variables have the following values:\n"
-    color blue "SALT: ${SALT}"
-    color blue "IV: ${IV}"
-    color blue "AUTH_TAG: ${AUTH_TAG}"
-    color yellow "E2E_PASSWORD_0: ${ACTUAL_BUDGET_E2E_PASSWORD_0}"
-	color yellow "E2E_PASSWORD: ${ACTUAL_BUDGET_E2E_PASSWORD}"
-    #aes-256-gcm-decrypt.py requires SALT, IV, and AUTH_TAG exported above in addition to user set ACTUAL_BUDGET_E2E_PASSWORD_X
-    if ! python3 /app/aes-256-gcm-decrypt.py; then
-        color red "Decryption failed. Encrypted backup ${BACKUP_FILE_ZIP} will be unusable. Check python error statement above for details"
-    fi
-    #We can delete the original encrypted file and rename the decrypted file so upload works as expected
-    rm "${BACKUP_FILE_ZIP}"
+    local SALT=$(curl "${ACTUAL_BUDGET_URL}/sync/user-get-key" -X POST -H "Content-Type: application/json" --data-raw "$JSON" | jq --raw-output ".data.salt")
+    local IV=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/get-user-file-info" \--header "X-ACTUAL-TOKEN: $TOKEN" \--header "X-ACTUAL-FILE-ID: $FILE_ID" | jq --raw-output ".data.encryptMeta.iv")
+    local AUTH_TAG=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/get-user-file-info" \--header "X-ACTUAL-TOKEN: $TOKEN" \--header "X-ACTUAL-FILE-ID: $FILE_ID" | jq --raw-output ".data.encryptMeta.authTag")
+
+    #Set the password index to match X from ACTUAL_BUDGET_SYNC_ID_X
+	#This will fail if not user defined
+	local E2E_PASSWORD_X="${ACTUAL_BUDGET_E2E_PASSWORD_LIST[$1]}"
+	color yellow "[DEBUG] E2E_PASSWORD_$1: ${E2E_PASSWORD_X}"
+	color red "[HARD DEBUG] E2E_PASSWORD_1: ${E2E_PASSWORD_1}"
+
     local DECRYPT_FILE_ZIP="${BACKUP_FILE_ZIP:0:-4}-decrypted.zip"
-    mv "${DECRYPT_FILE_ZIP}" "${BACKUP_FILE_ZIP}"
+	
+	#aes-256-gcm-decrypt.py requires SALT, IV, and AUTH_TAG retrieved above in addition to user set ACTUAL_BUDGET_E2E_PASSWORD_X
+	if ! python3 /app/aes-256-gcm-decrypt.py \
+	    "--salt=${SALT}" \
+		"--password=${E2E_PASSWORD_X}" \
+		"--iv=${IV}" \
+		"--authtag=${AUTH_TAG}" \
+		"--input=${BACKUP_FILE_ZIP}" \
+		"--output=${DECRYPT_FILE_ZIP}"; then
+        #Unusable backup is kept as .bin in case of failure as you can still manually decrypt it given the same server state. Better to have it than not.
+		color red "Decryption failed. Encrypted backup ${BACKUP_FILE_ZIP} will be unusable. Check python error statement above for details"
+	else
+	    color blue "Decryption successful. Backing up ${BACKUP_FILE_ZIP}..."
+		#Delete the redundant .bin file
+		rm "${BACKUP_FILE_BIN}"
+		#Rename successfully decrypted backup file
+        mv "${DECRYPT_FILE_ZIP}" "${BACKUP_FILE_ZIP}"
+    fi
+
 }
 
 function backup() {
@@ -86,10 +101,12 @@ function upload() {
     for ACTUAL_BUDGET_SYNC_ID_X in "${ACTUAL_BUDGET_SYNC_ID_LIST[@]}"
     do
         backup_file_name $ACTUAL_BUDGET_SYNC_ID_X
-        if !(file "${BACKUP_FILE_ZIP}" | grep -q "Zip archive data" ) ; then
-            color red "File not found \"${BACKUP_FILE_ZIP}\""
-
-            exit 1
+		if !(file "${BACKUP_FILE_ZIP}" | grep -q "Zip archive data" ) ; then
+            color blue "File not found \"${BACKUP_FILE_ZIP}\". Looking for matching bin..."
+            if !(file "${BACKUP_FILE_BIN}") ; then
+				color red "File not found \"${BACKUP_FILE_BIN}\""
+				exit 1
+			fi
         fi
     done
     

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -22,18 +22,55 @@ function download_actual_budget() {
     color blue "Downloading Actual Budget backup"
     color green "Login into Actual Budget" 
     prepare_login_json
-    local TOKEN="$(curl -s --location "${ACTUAL_BUDGET_URL}/account/login" --header 'Content-Type: application/json' --data @/tmp/login.json  | jq --raw-output '.data.token')"
+    TOKEN="$(curl -s --location "${ACTUAL_BUDGET_URL}/account/login" --header 'Content-Type: application/json' --data @/tmp/login.json  | jq --raw-output '.data.token')"
     rm /tmp/login.json
     for ACTUAL_BUDGET_SYNC_ID_X in "${ACTUAL_BUDGET_SYNC_ID_LIST[@]}"
     do
         color green "Get file id for ${ACTUAL_BUDGET_SYNC_ID_X}"
         backup_file_name $ACTUAL_BUDGET_SYNC_ID_X
 
-        local FILE_ID=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/list-user-files" \--header "X-ACTUAL-TOKEN: $TOKEN" | jq --raw-output ".data[] | select( [ .groupId | match(\"$ACTUAL_BUDGET_SYNC_ID_X\") ] | any) | .fileId")
+        #Explicit exports in this file are needed for visibility from python
+        export FILE_ID=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/list-user-files" \--header "X-ACTUAL-TOKEN: $TOKEN" | jq --raw-output ".data[] | select( [ .groupId | match(\"$ACTUAL_BUDGET_SYNC_ID_X\") ] | any) | .fileId")
         color green "Downloading backup files"
         curl -s --location "${ACTUAL_BUDGET_URL}/sync/download-user-file" --header "X-ACTUAL-TOKEN: $TOKEN" --header "X-ACTUAL-FILE-ID: $FILE_ID" --output "${BACKUP_FILE_ZIP}"
+        ENCRYPT_KEY_ID=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/list-user-files" \--header "X-ACTUAL-TOKEN: $TOKEN" | jq --raw-output ".data[] | select( [ .groupId | match(\"$ACTUAL_BUDGET_SYNC_ID_X\") ] | any) | .encryptKeyId")
+		color blue "[DEBUG] ENCRYPT_KEY_ID: ${ENCRYPT_KEY_ID}"
+        if [ "$ENCRYPT_KEY_ID" != "null" ]; then
+            decrypt
+        fi
     done
    
+}
+
+function decrypt() {
+    color blue "File ${BACKUP_FILE_ZIP} is encrypted. Decrypting data..."
+    
+    #FILE_ID and ENCRYPT_KEY_ID are still set to the current file so they can be used here
+    #TOKEN is cross function
+    color yellow "[DEBUG]Attempting to get SALT"
+    local JSON=$(jq -n --arg token "$TOKEN" --arg fileId "$FILE_ID" \
+  '{token: $token, fileId: $fileId}')
+    export SALT=$(curl "${ACTUAL_BUDGET_URL}/sync/user-get-key" -X POST -H "Content-Type: application/json" --data-raw "$JSON" | jq --raw-output ".data.salt")
+    color yellow "[DEBUG] Attempting to get IV"
+    export IV=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/get-user-file-info" \--header "X-ACTUAL-TOKEN: $TOKEN" \--header "X-ACTUAL-FILE-ID: $FILE_ID" | jq --raw-output ".data.encryptMeta.iv")
+    color yellow "[DEBUG] Attempting to get Auth_Tag"
+    export AUTH_TAG=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/get-user-file-info" \--header "X-ACTUAL-TOKEN: $TOKEN" \--header "X-ACTUAL-FILE-ID: $FILE_ID" | jq --raw-output ".data.encryptMeta.authTag")
+	export E2E_PASS_ARG="${ACTUAL_BUDGET_E2E_PASSWORD}"
+	export BACKUP_FILE_ZIP_ARG="${BACKUP_FILE_ZIP}"
+    color blue "[DEBUG] Required variables have the following values:\n"
+    color blue "SALT: ${SALT}"
+    color blue "IV: ${IV}"
+    color blue "AUTH_TAG: ${AUTH_TAG}"
+    color yellow "E2E_PASSWORD_0: ${ACTUAL_BUDGET_E2E_PASSWORD_0}"
+	color yellow "E2E_PASSWORD: ${ACTUAL_BUDGET_E2E_PASSWORD}"
+    #aes-256-gcm-decrypt.py requires SALT, IV, and AUTH_TAG exported above in addition to user set ACTUAL_BUDGET_E2E_PASSWORD_X
+    if ! python3 /app/aes-256-gcm-decrypt.py; then
+        color red "Decryption failed. Encrypted backup ${BACKUP_FILE_ZIP} will be unusable. Check python error statement above for details"
+    fi
+    #We can delete the original encrypted file and rename the decrypted file so upload works as expected
+    rm "${BACKUP_FILE_ZIP}"
+    local DECRYPT_FILE_ZIP="${BACKUP_FILE_ZIP:0:-4}-decrypted.zip"
+    mv "${DECRYPT_FILE_ZIP}" "${BACKUP_FILE_ZIP}"
 }
 
 function backup() {
@@ -95,6 +132,7 @@ function clear_history() {
 }
 
 
+DECRYPT=0
 
 color blue "running the backup program at $(date +"%Y-%m-%d %H:%M:%S %Z")"
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -36,9 +36,9 @@ function download_actual_budget() {
         color green "Downloading backup files"
         curl -s --location "${ACTUAL_BUDGET_URL}/sync/download-user-file" --header "X-ACTUAL-TOKEN: $TOKEN" --header "X-ACTUAL-FILE-ID: $FILE_ID" --output "${BACKUP_FILE_ZIP}"
         ENCRYPT_KEY_ID=$(curl -s --location "${ACTUAL_BUDGET_URL}/sync/list-user-files" \--header "X-ACTUAL-TOKEN: $TOKEN" | jq --raw-output ".data[] | select( [ .groupId | match(\"$ACTUAL_BUDGET_SYNC_ID_X\") ] | any) | .encryptKeyId")
-		color blue "[DEBUG] ENCRYPT_KEY_ID: ${ENCRYPT_KEY_ID}"
         if [ "$ENCRYPT_KEY_ID" != "null" ]; then
-            BACKUP_FILE_BIN="${BACKUP_FILE_ZIP:0:-4}.bin"
+            color blue "File ${BACKUP_FILE_ZIP} is encrypted with Encryption ID: ${ENCRYPT_KEY_ID}. Decrypting data..."
+			BACKUP_FILE_BIN="${BACKUP_FILE_ZIP:0:-4}.bin"
 			cp "${BACKUP_FILE_ZIP}" "${BACKUP_FILE_BIN}"
 			decrypt "${i}"
 		else
@@ -50,9 +50,6 @@ function download_actual_budget() {
 }
 
 function decrypt() {
-	color blue "File ${BACKUP_FILE_ZIP} is encrypted. Decrypting data..."
-    
-    
 	#$FILE_ID and $TOKEN are still set properly so they can be used here
     local JSON=$(jq -n --arg token "$TOKEN" --arg fileId "$FILE_ID" \
   '{token: $token, fileId: $fileId}')
@@ -63,8 +60,6 @@ function decrypt() {
     #Set the password index to match X from ACTUAL_BUDGET_SYNC_ID_X
 	#This will fail if not user defined
 	local E2E_PASSWORD_X="${ACTUAL_BUDGET_E2E_PASSWORD_LIST[$1]}"
-	color yellow "[DEBUG] E2E_PASSWORD_$1: ${E2E_PASSWORD_X}"
-	color red "[HARD DEBUG] E2E_PASSWORD_1: ${E2E_PASSWORD_1}"
 
     local DECRYPT_FILE_ZIP="${BACKUP_FILE_ZIP:0:-4}-decrypted.zip"
 	
@@ -77,14 +72,14 @@ function decrypt() {
 		"--input=${BACKUP_FILE_ZIP}" \
 		"--output=${DECRYPT_FILE_ZIP}"; then
         #Unusable backup is kept as .bin in case of failure as you can still manually decrypt it given the same server state. Better to have it than not.
-		color red "Decryption failed. Encrypted backup ${BACKUP_FILE_ZIP} will be unusable. Check python error statement above for details"
+		color red "Decryption failed. Encrypted backup ${BACKUP_FILE_ZIP} is unusable. Check python error statement above for details"
 	else
 	    color blue "Decryption successful. Backing up ${BACKUP_FILE_ZIP}..."
-		#Delete the redundant .bin file
-		rm "${BACKUP_FILE_BIN}"
 		#Rename successfully decrypted backup file
         mv "${DECRYPT_FILE_ZIP}" "${BACKUP_FILE_ZIP}"
     fi
+	#Delete the redundant .bin file
+	rm "${BACKUP_FILE_BIN}"
 
 }
 
@@ -102,11 +97,10 @@ function upload() {
     do
         backup_file_name $ACTUAL_BUDGET_SYNC_ID_X
 		if !(file "${BACKUP_FILE_ZIP}" | grep -q "Zip archive data" ) ; then
-            color blue "File not found \"${BACKUP_FILE_ZIP}\". Looking for matching bin..."
-            if !(file "${BACKUP_FILE_BIN}") ; then
-				color red "File not found \"${BACKUP_FILE_BIN}\""
-				exit 1
-			fi
+            color red "File not found \"${BACKUP_FILE_ZIP}\""
+			color red "This may be a file which failed to properly decrypt and will not be backed up"
+			color red "Nothing has been backed up!"
+            exit 1
         fi
     done
     

--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -207,6 +207,9 @@ function init_actual_env(){
     ACTUAL_BUDGET_SYNC_ID_0="${ACTUAL_BUDGET_SYNC_ID}"
 
     init_actual_sync_list
+	
+	get_env ACTUAL_BUDGET_E2E_PASSWORD
+	ACTUAL_BUDGET_E2E_PASSWORD_0="${ACTUAL_BUDGET_E2E_PASSWORD}"
 }
 
 ########################################

--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -209,7 +209,7 @@ function init_actual_e2e_list(){
 
     for ACTUAL_BUDGET_E2E_PASSWORD_X in "${ACTUAL_BUDGET_E2E_PASSWORD_LIST[@]}"
     do
-        color yellow "ACTUAL_BUDGET_E2E_PASSWORD: ${ACTUAL_BUDGET_E2E_PASSWORD_X}"
+        color yellow "ACTUAL_BUDGET_E2E_PASSWORD: *****"
     done
 }
 

--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -187,6 +187,32 @@ function init_actual_sync_list() {
     done
 }
 
+function init_actual_e2e_list(){
+    ACTUAL_BUDGET_E2E_PASSWORD_LIST=()
+
+    local i=0
+    local ACTUAL_BUDGET_E2E_PASSWORD_X_REFER
+
+    # for multiple
+    while true; do
+        ACTUAL_BUDGET_E2E_PASSWORD_X_REFER="ACTUAL_BUDGET_E2E_PASSWORD_${i}"
+        get_env "${ACTUAL_BUDGET_E2E_PASSWORD_X_REFER}"
+    
+        if [[ -z "${!ACTUAL_BUDGET_E2E_PASSWORD_X_REFER}" ]]; then        
+            break
+        fi
+        
+        ACTUAL_BUDGET_E2E_PASSWORD_LIST=(${ACTUAL_BUDGET_E2E_PASSWORD_LIST[@]} ${!ACTUAL_BUDGET_E2E_PASSWORD_X_REFER})
+
+        ((i++))
+    done
+
+    for ACTUAL_BUDGET_E2E_PASSWORD_X in "${ACTUAL_BUDGET_E2E_PASSWORD_LIST[@]}"
+    do
+        color yellow "ACTUAL_BUDGET_E2E_PASSWORD: ${ACTUAL_BUDGET_E2E_PASSWORD_X}"
+    done
+}
+
 function init_actual_env(){
     # ACTUAL BUDGET
     get_env ACTUAL_BUDGET_URL
@@ -208,8 +234,11 @@ function init_actual_env(){
 
     init_actual_sync_list
 	
+	
 	get_env ACTUAL_BUDGET_E2E_PASSWORD
 	ACTUAL_BUDGET_E2E_PASSWORD_0="${ACTUAL_BUDGET_E2E_PASSWORD}"
+	
+	init_actual_e2e_list
 }
 
 ########################################


### PR DESCRIPTION
Resolves #5

Prerequisites added: python, pycryptodome

This implements support for backing up End-to-end encrypted backups, as long as the env variable `ACTUAL_BUDGET_E2E_PASSWORD` is specified

Multiple encrypted backups are supported with `ACTUAL_BUDGET_E2E_PASSWORD_N`, with the same requirement of unbroken continuity as `ACTUAL_BUDGET_SYNC_ID_N`