### PR TITLE
feat: Using the Actual budget actual-app/api npm package to backup th…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG USER_ID="1100"
 
 ENV LOCALTIME_FILE="/tmp/localtime"
 
+COPY scripts/*.js /app/
 COPY scripts/*.sh /app/
 COPY scripts/*.py /app/
 

--- a/scripts/download-actual-budget.js
+++ b/scripts/download-actual-budget.js
@@ -1,0 +1,47 @@
+const api = require('@actual-app/api');
+const path = require('path');
+const { execSync } = require('child_process');
+const argv = require('minimist')(process.argv.slice(2));
+
+// Parse arguments using minimist
+const dataDir = argv.dataDir || '/tmp/actual-download';
+const destDir = argv.destDir || '/data/backup';
+const serverURL = argv.serverURL || 'http://localhost:5006';
+const password = argv.password || 'password';
+const syncIdList = (argv.syncIds || '').split(',');
+const e2ePasswords = (argv.e2ePasswords || '').split(',');
+const now = argv.now || 'now';
+
+console.log("📥 Starting download from", serverURL);
+console.log("🗂 Sync IDs:", syncIdList);
+
+(async () => {
+    for (let i = 0; i < syncIdList.length; i++) {
+        const syncId = syncIdList[i];
+        if (!syncId) continue;
+
+        const e2ePassword = e2ePasswords[i] || null;
+        const zipPath = path.join(destDir, `backup.${syncId}.${now}.zip`);
+
+        console.log(`⬇️  Downloading budget ${syncId} -> ${zipPath}`);
+
+        await api.init({ dataDir, serverURL, password });
+
+        try {
+            await api.downloadBudget(syncId, e2ePassword ? { password: e2ePassword } : {});
+            console.log(`✅ Budget ${syncId} downloaded successfully.`);
+            await api.getAccounts();
+            await api.shutdown();
+
+            // Zip the downloaded data
+            execSync(`cd ${dataDir} && zip -r ${zipPath} .`, { stdio: 'inherit' });
+            console.log(`📦 Created zip: ${zipPath}`);
+        } catch (err) {
+            console.error(`❌ Failed to download ${syncId}:`, err);
+        } finally {
+            await api.shutdown();
+        }
+    }
+
+    console.log("🎉 All downloads completed!");
+})();


### PR DESCRIPTION
Hello,

As discussed on Discord, when downloading the zip file form the server, it doesn't contain the latest changes since Actual budget has a local-first approach to handling the data.

This change uses the actual-app/api nodejs package to download the budget file.

Tested with:
```
docker run --rm -it \
  -v "$(pwd)/backup:/app/backup" \
  --mount type=volume,source=actualbudget-rclone-data,target=/config/ \
  -e ACTUAL_BUDGET_URL="https://<actualurl>" \
  -e ACTUAL_BUDGET_PASSWORD="<password>" \
  -e ACTUAL_BUDGET_SYNC_ID="<sync-id>" \
  -e RCLONE_REMOTE_NAME="ActualBudgetBackup" \
  -e RCLONE_REMOTE_DIR="/data/backup/ActualBudgetBackup" \
  actual-backup:latest backup
```

Cons:
- It defaults to latest when fetching the nodejs package, and if the package latest version is different from the user's Actual budget version, the downloading may not work. In this case the user would have to either 1) provide a specific version for actual using the env var `ACTUAL_API_VERSION`, or 2) update its Actual budget server to the latest version.

Thoughts?