### PR TITLE
update rclone version to add pixeldrain support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rclone/rclone:1.66.0
+FROM rclone/rclone:1.72.0
 
 LABEL "repository"="https://github.com/rodriguestiago0/actual-backup" \
   "homepage"="https://github.com/rodriguestiago0/actual-backup"


### PR DESCRIPTION
Hello, I was looking forward to using this docker container to backup my actual database.

I wanted to use `pixeldrain` as one of the remotes to upload my backup to. This is currently not possible due to pixeldrain being added in **v1.68**, but the rclone version used here is **v1.66**.

I've decided to update the rclone version to the latest, which as of this writing is **v1.72**. If **v1.68** is preferred for the sake of just adding pixeldrain support, I can update it. Thank you!