### PR TITLE
feat: update rclone to 1.75.0, add 7zip encryption, fix timezone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# 1. Please put the value in double quotes to avoid problems.
+# 2. To use the file, you need to map the file to `/.env` in the container.
+
+# RCLONE_REMOTE_NAME="ActualBudgetBackup"
+# RCLONE_REMOTE_DIR="/ActualBudgetBackup/"
+# RCLONE_GLOBAL_FLAG=""
+# CRON="0 0 * * *"
+# ZIP_ENABLE="TRUE"
+# ZIP_PASSWORD=""
+# ZIP_TYPE="zip"
+# BACKUP_FILE_SUFFIX="%Y%m%d"
+# BACKUP_KEEP_DAYS="0"
+# TIMEZONE="UTC"
+# ACTUAL_BUDGET_URL= #without quotes and the last /
+# ACTUAL_BUDGET_PASSWORD= #without quotes
+# ACTUAL_BUDGET_SYNC_ID= #without quotes
+# ACTUAL_BUDGET_E2E_PASSWORD=#without quotes

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 # Log
 *.log
 *.log.*
+
+# Env
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
-FROM rclone/rclone:sha-73bcae2
-# FROM rclone/rclone:1.72.1
+FROM rclone/rclone:sha-9ee9d0a
+# FROM rclone/rclone:1.75.0
 
 LABEL "repository"="https://github.com/rodriguestiago0/actual-backup" \
   "homepage"="https://github.com/rodriguestiago0/actual-backup"
@@ -15,7 +15,7 @@ COPY scripts/*.js /app/
 COPY scripts/*.sh /app/
 
 RUN chmod +x /app/* \
-  && apk add --no-cache grep file bash supercronic curl jq zip nodejs npm wget tar xz \
+  && apk add --no-cache grep file bash supercronic curl jq zip 7zip nodejs npm wget tar xz tzdata \
   && ln -sf "${LOCALTIME_FILE}" /etc/localtime \
   && addgroup -g "${USER_ID}" "${USER_NAME}" \
   && adduser -u "${USER_ID}" -Ds /bin/sh -G "${USER_NAME}" "${USER_NAME}"

--- a/README.md
+++ b/README.md
@@ -53,22 +53,22 @@ docker run --rm -it \
 
 #### Use Docker Compose (Recommend)
 
-Download `docker-compose.yml` to you machine, edit the [environment variables](#environment-variables) and start it.
+Download `compose.yaml` to you machine, edit the [environment variables](#environment-variables) and start it.
 
-You need to go to the directory where the `docker-compose.yml` file is saved.
+You need to go to the directory where the `compose.yaml` file is saved.
 
 ```shell
 # Start
-docker-compose up -d
+docker compose up -d
 
 # Stop
-docker-compose stop
+docker compose stop
 
 # Restart
-docker-compose restart
+docker compose restart
 
 # Remove
-docker-compose down
+docker compose down
 ```
 
 #### Automatic Backups without docker compose
@@ -83,29 +83,6 @@ docker run -d \
   rodriguestiago0/actualbudget-backup:latest
 ```
 
-#### Automatic Backups with systemd
-
-Instead of relying on the container's built-in cron schedule, you can use systemd timers to trigger your backups. This repository includes a systemd service (`systemd/actualbudget-backup.service`) and a timer (`systemd/actualbudget-backup.timer`) that you can use.
-
-**Installation Manual:**
-
-1. Edit the `WorkingDirectory` in `systemd/actualbudget-backup.service` to point to the directory containing your `docker-compose.yml`.
-2. Copy both files to the systemd directory:
-   ```shell
-   sudo cp systemd/actualbudget-backup.service /etc/systemd/system/
-   sudo cp systemd/actualbudget-backup.timer /etc/systemd/system/
-   ```
-3. Reload the systemd manager configuration:
-   ```shell
-   sudo systemctl daemon-reload
-   ```
-4. Enable and start the timer so it runs automatically:
-   ```shell
-   sudo systemctl enable --now actualbudget-backup.timer
-   ```
-
-By default, the provided timer is configured to run daily at `00:00`. You can customize this schedule by editing the `OnCalendar` rule in the `actualbudget-backup.timer` file.
-
 ## Environment Variables
 
 > **Note:** The container will run with no environment variables specified without error, however if you haven't set at least `ACTUAL_BUDGET_URL`, `ACTUAL_BUDGET_PASSWORD`, and `ACTUAL_BUDGET_SYNC_ID`, no backup will successfully happen.
@@ -116,15 +93,11 @@ URL for the actual budget server, without a trailing `/`
 
 ### ACTUAL_BUDGET_PASSWORD
 
-Password for the actual budget server. If you're setting this through the docker-compose file, Single quotes must be escaped with by doubling them up. e.g. if your password is `SuperGo'oodPassw\ord"1` you would enter `ACTUAL_BUDGET_PASSWORD: 'SuperGo''oodPassw\ord"1'`. If you're using the env file method, you will need to work out your own way to encode your password without breaking the env file.
+Password for the actual budget server. If you're setting this through the compose file, Single quotes must be escaped with by doubling them up. e.g. if your password is `SuperGo'oodPassw\ord"1` you would enter `ACTUAL_BUDGET_PASSWORD: 'SuperGo''oodPassw\ord"1'`. If you're using the env file method, you will need to work out your own way to encode your password without breaking the env file.
 
 ### ACTUAL_BUDGET_SYNC_ID
 
 Actual Sync ID. You can find this by logging into your Actual server in a web browser, go to `settings > show advanced settings` and the sync ID should be in the top block there.
-
-### ACTUAL_API_VERSION
-
-Optional version of the `@actual-app/api` package used by the backup process. This can be used to pin a specific version, for example `ACTUAL_API_VERSION: 'latest'` or `ACTUAL_API_VERSION: '25.8.0'`. If omitted, the container defaults to `latest`.
 
 ### RCLONE_REMOTE_NAME
 
@@ -157,6 +130,24 @@ Rclone global flags, see [flags](https://rclone.org/flags/).
 **Do not add flags that will change the output, such as `-P`, which will affect the deletion of outdated backup files.**
 
 Default: `''`
+
+### ZIP_ENABLE
+
+Pack all backup files into a compressed archive. When set to `'FALSE'`, each backup file will be a uncompressed tar archive.
+
+Default: `TRUE`
+
+### ZIP_PASSWORD
+
+The password for the compressed archive. When set, the archive will be encrypted with this password. Leave empty for no password.
+
+Default: `''` (no password)
+
+### ZIP_TYPE
+
+The archive format. Supports `zip` and `7z`. The `7z` format provides better compression and encryption (header encryption with `-mhe=on`).
+
+Default: `zip`
 
 ### CRON
 
@@ -222,7 +213,7 @@ Default: `''`
 
 ## Using `.env` file
 
-If you prefer using an env file instead of environment variables, you can map the env file containing the environment variables to the `/.env` file in the container.
+If you prefer using an env file instead of environment variables, you can map the env file containing the environment variables to the `/.env` file in the container. A template with all supported variables (commented out) is provided as [`.env.example`](/.env.example) — copy it to `.env` and fill in your values.
 
 ```shell
 docker run -d \

--- a/README.md
+++ b/README.md
@@ -83,6 +83,29 @@ docker run -d \
   rodriguestiago0/actualbudget-backup:latest
 ```
 
+#### Automatic Backups with systemd
+
+Instead of relying on the container's built-in cron schedule, you can use systemd timers to trigger your backups. This repository includes a systemd service (`systemd/actualbudget-backup.service`) and a timer (`systemd/actualbudget-backup.timer`) that you can use.
+
+**Installation Manual:**
+
+1. Edit the `WorkingDirectory` in `systemd/actualbudget-backup.service` to point to the directory containing your `compose.yaml`.
+2. Copy both files to the systemd directory:
+   ```shell
+   sudo cp systemd/actualbudget-backup.service /etc/systemd/system/
+   sudo cp systemd/actualbudget-backup.timer /etc/systemd/system/
+   ```
+3. Reload the systemd manager configuration:
+   ```shell
+   sudo systemctl daemon-reload
+   ```
+4. Enable and start the timer so it runs automatically:
+   ```shell
+   sudo systemctl enable --now actualbudget-backup.timer
+   ```
+
+By default, the provided timer is configured to run daily at `00:00`. You can customize this schedule by editing the `OnCalendar` rule in the `actualbudget-backup.timer` file.
+
 ## Environment Variables
 
 > **Note:** The container will run with no environment variables specified without error, however if you haven't set at least `ACTUAL_BUDGET_URL`, `ACTUAL_BUDGET_PASSWORD`, and `ACTUAL_BUDGET_SYNC_ID`, no backup will successfully happen.
@@ -98,6 +121,10 @@ Password for the actual budget server. If you're setting this through the compos
 ### ACTUAL_BUDGET_SYNC_ID
 
 Actual Sync ID. You can find this by logging into your Actual server in a web browser, go to `settings > show advanced settings` and the sync ID should be in the top block there.
+
+### ACTUAL_API_VERSION
+
+Optional version of the `@actual-app/api` package used by the backup process. This can be used to pin a specific version, for example `ACTUAL_API_VERSION: 'latest'` or `ACTUAL_API_VERSION: '25.8.0'`. If omitted, the container defaults to `latest`.
 
 ### RCLONE_REMOTE_NAME
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,27 @@
+services:
+  backup:
+    image: rodriguestiago0/actualbudget-backup:latest
+    restart: always
+    environment:
+    #   RCLONE_REMOTE_NAME: 'ActualBudgetBackup'
+    #   RCLONE_REMOTE_DIR: '/ActualBudgetBackup/'
+    #   RCLONE_GLOBAL_FLAG: ''
+        ACTUAL_BUDGET_URL: 'https://actual.example.com'
+        ACTUAL_BUDGET_PASSWORD: ''
+        ACTUAL_BUDGET_SYNC_ID: ''
+    #   ACTUAL_BUDGET_E2E_PASSWORD: ''
+    #   CRON: '0 0 * * *'
+    #   ZIP_ENABLE: 'TRUE'
+    #   ZIP_PASSWORD: ''
+    #   ZIP_TYPE: 'zip'
+    #   BACKUP_FILE_SUFFIX: '%Y%m%d'
+    #   BACKUP_KEEP_DAYS: 0
+    #   TIMEZONE: 'UTC'
+    volumes:
+      - actualbudget-rclone-data:/config/
+    #   - /path/to/env:/.env
+    
+volumes:
+  actualbudget-rclone-data:
+    external: true
+    name: actualbudget-rclone-data

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ The only thing to note that we're doing differently is that Rclone is running in
 
 ### Connection to Actual
 
-Next you need to tell the container how it's going to talk to your Actual server. To start with, download the [`docker-compose.yml`](/docker-compose.yml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. This guide will go over the mandatory and most used fields here. For the the full list, check the [README](/README.md) for what they do.
+Next you need to tell the container how it's going to talk to your Actual server. To start with, download the [`compose.yaml`](/compose.yaml?raw=1) file to your machine. Put it in its own folder somewhere, and then open it for editing. This guide will go over the mandatory and most used fields here. For the the full list, check the [README](/README.md) for what they do.
 
 #### Mandatory fields
 
@@ -45,8 +45,6 @@ Next you need to tell the container how it's going to talk to your Actual server
 `BACKUP_KEEP_DAYS` - by default, this tool never deletes old backups. To change this behaviour, set this to the number of days to keep backups for. e.g. for a weeks worth of backups, set `BACKUP_KEEP_DAYS: 7`
 
 `ACTUAL_BUDGET_SYNC_ID_1` If you have multiple budgets to backup, you can add more sync IDs by using the `ACTUAL_BUDGET_SYNC_ID_1: ''` field to hold the second ID, and you can add as many of those as you want by incrementing the number `ACTUAL_BUDGET_SYNC_ID_2`, `ACTUAL_BUDGET_SYNC_ID_3`… etc.
-
-`ACTUAL_API_VERSION` - Optional. Pin the version of the `@actual-app/api` package used by the backup script. For example, `ACTUAL_API_VERSION: 'latest'` or `ACTUAL_API_VERSION: '25.8.0'`. If you do not set this, the container uses `latest` by default.
 
 ## Testing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,8 @@ Next you need to tell the container how it's going to talk to your Actual server
 
 `ACTUAL_BUDGET_SYNC_ID_1` If you have multiple budgets to backup, you can add more sync IDs by using the `ACTUAL_BUDGET_SYNC_ID_1: ''` field to hold the second ID, and you can add as many of those as you want by incrementing the number `ACTUAL_BUDGET_SYNC_ID_2`, `ACTUAL_BUDGET_SYNC_ID_3`… etc.
 
+`ACTUAL_API_VERSION` - Optional. Pin the version of the `@actual-app/api` package used by the backup script. For example, `ACTUAL_API_VERSION: 'latest'` or `ACTUAL_API_VERSION: '25.8.0'`. If you do not set this, the container uses `latest` by default.
+
 ## Testing
 
 Now all the config is set, you should run a test backup to confirm all the config is correct. To do that, run the following command from the folder where you have the docker compose file:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -7,8 +7,8 @@ function clear_dir() {
 }
 
 function backup_file_name () {
-    # backup zip file
-    BACKUP_FILE_ZIP="backup/backup.$1.${NOW}.zip"
+    # backup archive file
+    BACKUP_FILE_ZIP="backup/backup.$1.${NOW}.${ZIP_TYPE}"
     color blue "file name \"${BACKUP_FILE_ZIP}\""
 }
 
@@ -54,7 +54,10 @@ function download_actual_budget() {
         --destDir="$(pwd)/backup" \
         --serverURL="$ACTUAL_BUDGET_URL" \
         --password="$ACTUAL_BUDGET_PASSWORD" \
-        --now="$NOW"
+        --now="$NOW" \
+        --zipEnable="$ZIP_ENABLE" \
+        --zipType="$ZIP_TYPE" \
+        --zipPassword="$ZIP_PASSWORD"
 }
 
 # ==========================================================
@@ -72,9 +75,9 @@ function upload() {
     for ACTUAL_BUDGET_SYNC_ID_X in "${ACTUAL_BUDGET_SYNC_ID_LIST[@]}"
     do
         backup_file_name $ACTUAL_BUDGET_SYNC_ID_X
-		if !(file "${BACKUP_FILE_ZIP}" | grep -q "data" ) ; then
-            color red "File not found \"${BACKUP_FILE_ZIP}\""
-			color red "Nothing has been backed up!"
+        if [[ ! -s "${BACKUP_FILE_ZIP}" ]]; then
+            color red "File not found or empty \"${BACKUP_FILE_ZIP}\""
+            color red "Nothing has been backed up!"
             exit 1
         fi
     done
@@ -123,7 +126,7 @@ init_env
 
 NOW="$(date +"${BACKUP_FILE_DATE_FORMAT}")"
 
-check_rclone_connection
+check_rclone_connection any
 
 clear_dir
 backup

--- a/scripts/download-actual-budget.js
+++ b/scripts/download-actual-budget.js
@@ -11,19 +11,45 @@ const password = argv.password || 'password';
 const syncIdList = (argv.syncIds || '').split(',');
 const e2ePasswords = (argv.e2ePasswords || '').split(',');
 const now = argv.now || 'now';
+const zipEnable = argv.zipEnable !== 'FALSE';
+const zipType = argv.zipType === '7z' ? '7z' : 'zip';
+const zipPassword = argv.zipPassword || '';
 
 console.log("📥 Starting download from", serverURL);
 console.log("🗂 Sync IDs:", syncIdList);
+console.log("📦 Archive format:", zipEnable ? zipType : 'none (uncompressed)');
+console.log("🔒 Password protection:", zipPassword ? 'enabled' : 'disabled');
+
+function buildArchiveCommand(sourceDir, zipPath) {
+    if (!zipEnable) {
+        // uncompressed: use tar (no password support)
+        return `cd ${sourceDir} && tar -cf ${zipPath} .`;
+    }
+    if (zipType === '7z') {
+        const pwFlag = zipPassword ? `-p"${zipPassword}" -mhe=on` : '';
+        return `cd ${sourceDir} && 7z a -t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on ${pwFlag} "${zipPath}" .`;
+    }
+    // zip
+    const pwFlag = zipPassword ? `-p"${zipPassword}"` : '';
+    return `cd ${sourceDir} && 7z a -tzip -mx=9 ${pwFlag} "${zipPath}" .`;
+}
+
+function archiveExtension() {
+    if (!zipEnable) return 'tar';
+    return zipType;
+}
 
 (async () => {
+    const ext = archiveExtension();
+
     for (let i = 0; i < syncIdList.length; i++) {
         const syncId = syncIdList[i];
         if (!syncId) continue;
 
         const e2ePassword = e2ePasswords[i] || null;
-        const zipPath = path.join(destDir, `backup.${syncId}.${now}.zip`);
+        const archivePath = path.join(destDir, `backup.${syncId}.${now}.${ext}`);
 
-        console.log(`⬇️  Downloading budget ${syncId} -> ${zipPath}`);
+        console.log(`⬇️  Downloading budget ${syncId} -> ${archivePath}`);
 
         await api.init({ dataDir, serverURL, password });
 
@@ -33,10 +59,12 @@ console.log("🗂 Sync IDs:", syncIdList);
             await api.getAccounts();
             await api.shutdown();
 
-            // Zip the downloaded data
-            execSync(`cd ${dataDir} && zip -r ${zipPath} .`, { stdio: 'inherit' });
+            // Create the archive
+            const cmd = buildArchiveCommand(dataDir, archivePath);
+            console.log(`📦 Creating archive: ${archivePath}`);
+            execSync(cmd, { stdio: 'inherit' });
             execSync(`rm -rf ${dataDir}/*`, { stdio: 'inherit' });
-            console.log(`📦 Created zip: ${zipPath}`);
+            console.log(`📦 Archive created: ${archivePath}`);
         } catch (err) {
             console.error(`❌ Failed to download ${syncId}:`, err);
         } finally {

--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -301,6 +301,26 @@ function init_env() {
     get_env BACKUP_KEEP_DAYS
     BACKUP_KEEP_DAYS="${BACKUP_KEEP_DAYS:-"0"}"
 
+    # ZIP_ENABLE
+    get_env ZIP_ENABLE
+    if [[ "${ZIP_ENABLE^^}" == "FALSE" ]]; then
+        ZIP_ENABLE="FALSE"
+    else
+        ZIP_ENABLE="TRUE"
+    fi
+
+    # ZIP_PASSWORD
+    get_env ZIP_PASSWORD
+    ZIP_PASSWORD="${ZIP_PASSWORD:-""}"
+
+    # ZIP_TYPE
+    get_env ZIP_TYPE
+    if [[ "${ZIP_TYPE,,}" == "7z" ]]; then
+        ZIP_TYPE="7z"
+    else
+        ZIP_TYPE="zip"
+    fi
+
     # BACKUP_FILE_DATE_FORMAT
     get_env BACKUP_FILE_SUFFIX
     get_env BACKUP_FILE_DATE
@@ -326,6 +346,9 @@ function init_env() {
     done
 
     color yellow "RCLONE_GLOBAL_FLAG: ${RCLONE_GLOBAL_FLAG}"
+    color yellow "ZIP_ENABLE: ${ZIP_ENABLE}"
+    color yellow "ZIP_PASSWORD: ${#ZIP_PASSWORD} Chars"
+    color yellow "ZIP_TYPE: ${ZIP_TYPE}"
     color yellow "BACKUP_FILE_DATE_FORMAT: ${BACKUP_FILE_DATE_FORMAT} (example \"[filename].$(date +"${BACKUP_FILE_DATE_FORMAT}").zip\")"
     color yellow "BACKUP_KEEP_DAYS: ${BACKUP_KEEP_DAYS}"
 


### PR DESCRIPTION
## Summary

Updates rclone from 1.72.1 to 1.75.0, fixes a silent timezone bug, and adds 7z archive encryption support — inspired by ttionya/vaultwarden-backup to align features between both projects.

## Changes

### rclone update

- Updated base image from `rclone/rclone:sha-73bcae2` (1.72.1) to `rclone/rclone:sha-9ee9d0a` (1.75.0), pinned by SHA for reproducibility

### Timezone fix

- Added `tzdata` to the Dockerfile. Without it, `/usr/share/zoneinfo/` was empty and `TIMEZONE` always silently fell back to `UTC`, regardless of the env var value

### 7zip encryption support

- Added `7zip` to the Dockerfile
- New env vars: `ZIP_ENABLE`, `ZIP_PASSWORD`, `ZIP_TYPE` (supports `zip` and `7z`)
- 7z archives use `-mhe=on` for header encryption (file names are also encrypted)
- Backwards compatible: defaults are `ZIP_ENABLE=TRUE`, `ZIP_TYPE=zip`, `ZIP_PASSWORD=""` (no password) — same behaviour as before

### Connection check fix

- `check_rclone_connection` in `backup.sh` was called without arguments, so connection errors were silently ignored. Now uses `any` strategy (continues if some remotes fail, exits if all fail), matching vaultwarden-backup behaviour

### File validation fix

- Replaced `file | grep "data"` with `[[ ! -s ]]` for archive validation — works correctly with all formats (zip, 7z, tar)

### Repo conventions

- Renamed `docker-compose.yml` to `compose.yaml` (Compose spec canonical name)
- Added `.env.example` as committable template
- Added `.env` to `.gitignore` to prevent committing secrets
- Updated README and docs with `docker compose` v2 commands

## New env vars

| Variable | Default | Description |
|---|---|---|
| `ZIP_ENABLE` | `TRUE` | Pack backup into compressed archive (`FALSE` = uncompressed tar) |
| `ZIP_PASSWORD` | `""` | Password for the archive (empty = no password) |
| `ZIP_TYPE` | `zip` | Archive format: `zip` or `7z` |

## Breaking changes

None. All defaults match previous behaviour (zip without password).

## Testing

Tested on x86_64 with:

- Multiple rclone remotes (MEGA, pCloud, Filen, Clouflare R2 and more)
- 7z archives with password and header encryption
- Timezone set to `Europe/Madrid` (previously fell back to UTC)
- Multiple sync IDs with E2E encryption
- `BACKUP_KEEP_DAYS` retention across multiple remotes
